### PR TITLE
Added source folder to folders that can have music files and renamed BuildAListOfPotentialFoldersWithMusic method in MusicFileExtractor.cs

### DIFF
--- a/MusicPlayer/MusicPlayer/Controller/MusicFileExtractor.cs
+++ b/MusicPlayer/MusicPlayer/Controller/MusicFileExtractor.cs
@@ -6,7 +6,7 @@ namespace MusicPlayer.RepositoryControl
 {
     public class MusicFileExtractor
     {
-        readonly SourceFileRepository sourceFileRepository = RepositoryController.GetSourceFileRepository;
+        private readonly SourceFileRepository _sourceFileRepository = RepositoryController.GetSourceFileRepository;
 
         private const string Mp3Extension = ".mp3";
         private readonly static List<string> AcceptedFileExtensions = new List<string> {
@@ -15,15 +15,16 @@ namespace MusicPlayer.RepositoryControl
 
         public List<string> GetAllMusicFiles()
         {
-            var subDirectories = ExtractSubdirectories();
+            var subDirectories = BuildAListOfPotentialFoldersWithMusic();
             return ExtractMusicFiles(subDirectories);
         }
 
-        private List<string> ExtractSubdirectories()
+        private List<string> BuildAListOfPotentialFoldersWithMusic()
         {
-            var subFolderSet = new HashSet<string>();
-            sourceFileRepository.SourceDirectories.ForEach(entry => subFolderSet.UnionWith(GetAllFolderSubDirectories(entry)));
-            return subFolderSet.ToList();
+            var foldersThatMayContainMusic = new HashSet<string>();
+            _sourceFileRepository.SourceDirectories.ForEach(entry => foldersThatMayContainMusic.UnionWith(GetAllFolderSubDirectories(entry)));
+            _sourceFileRepository.SourceDirectories.ForEach(entry => foldersThatMayContainMusic.Add(entry));
+            return foldersThatMayContainMusic.ToList();
         }
 
         private List<string> ExtractMusicFiles(List<string> subFolderSet)

--- a/MusicPlayer/MusicPlayer/MainWindow.xaml.cs
+++ b/MusicPlayer/MusicPlayer/MainWindow.xaml.cs
@@ -1,18 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using System.Windows.Threading;
+﻿using System.Windows;
 
 namespace MusicPlayer
 {

--- a/MusicPlayer/MusicPlayer/UI/MainMenuPage.xaml.cs
+++ b/MusicPlayer/MusicPlayer/UI/MainMenuPage.xaml.cs
@@ -1,21 +1,5 @@
 ﻿using MusicPlayer.RepositoryControl;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using MusicPlayer.RepositoryControl;
-using System.IO;
-using System.Globalization;
 
 namespace MusicPlayer.UI
 {


### PR DESCRIPTION
In case music is directly in source directory, we didn't have the source directory as a folder that could be a music folder. Could this be added?

I added an underscore to sourceFileRepository. Usually, C# code will have a naming convention for member variables to differentiate them from local variables in methods.

Removed some unused usings.